### PR TITLE
Minor refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,27 +4,32 @@ PySpark isn't on sys.path by default, but that doesn't mean it can't be used as 
 You can address this by either symlinking pyspark into your site-packages,
 or adding pyspark to sys.path at runtime. `findspark` does the latter.
 
-This provides one function:
+To initialize PySpark, just call
 
 ```python
 import findspark
-findspark.find_spark()
+findspark.init()
 
 import pyspark
 sc = pyspark.SparkContext(appName="myAppName")
 ```
 
-If SPARK_HOME env is set, you don't need to pass any args.
-You can pass a path to spark_home to find_spark,
-and it will set SPARK_HOME:
-
-```python
-findspark.find_spark('/path/to/spark_home')
-```
-
-If you've installed spark with
+Without any arguments, the SPARK_HOME environmental variable will be used,
+and if that isn't set, other possible install locations will be checked. If
+you've installed spark with
 
     brew install apache-spark
 
-on OS X, the default location of `/usr/local/opt/apache-spark/libexec` will be searched
-if SPARK_HOME is not already set.
+on OS X, the location `/usr/local/opt/apache-spark/libexec` will be searched.
+
+Alternatively, you can specify a location with the `spark_home` argument.
+
+```python
+findspark.init('/path/to/spark_home')
+```
+
+To verify the automatically detected location, call
+
+```python
+findspark.find()
+```

--- a/findspark.py
+++ b/findspark.py
@@ -30,7 +30,7 @@ def find():
 
     if not spark_home:
         raise ValueError("Couldn't find Spark, make sure SPARK_HOME env is set"
-                         "or Spark is in an expected location (e.g. from homebrew installation).")
+                         " or Spark is in an expected location (e.g. from homebrew installation).")
 
     return spark_home
 

--- a/findspark.py
+++ b/findspark.py
@@ -1,4 +1,4 @@
-"""Find spark home, and add pyspark to sys.path.
+"""Find spark home, and initialize by adding pyspark to sys.path.
 
 If SPARK_HOME is defined, it will be used to put pyspark on sys.path.
 Otherwise, common locations for spark (currently only Homebrew's default) will be searched.
@@ -10,15 +10,15 @@ import sys
 
 __version__ = '0.0.2'
 
-def find_spark(spark_home=None):
-    """Find spark and make pyspark importable.
-    
-    Ensures SPARK_HOME is set and adds pyspark's location inside SPARK_HOME to sys.path.
-    
-    Common
+
+def find():
+    """Find a local spark installation
+
+    Will first check the SPARK_HOME env variable, and otherwise
+    search common installation locations, e.g. from homebrew
     """
-    if not spark_home:
-        spark_home = os.environ.get('SPARK_HOME', None)
+    spark_home = os.environ.get('SPARK_HOME', None)
+
     if not spark_home:
         for path in [
             '/usr/local/opt/apache-spark/libexec', # OS X Homebrew
@@ -27,16 +27,34 @@ def find_spark(spark_home=None):
             if os.path.exists(path):
                 spark_home = path
                 break
-    
+
     if not spark_home:
-        raise ValueError("Couldn't find spark, please specify spark_home arg or SPARK_HOME env.")
-    
+        raise ValueError("Couldn't find Spark, make sure SPARK_HOME env is set"
+                         " or Spark is in an expected location (e.g. from homebrew installation).")
+
+    return spark_home
+
+
+def init(spark_home=None):
+    """Make pyspark importable.
+
+    Sets environmental variables and adds dependencies to sys.path.
+    If no Spark location is provided, will try to find an installation.
+
+    Parameters
+    ----------
+    spark_home : str, optional, default = None
+        Path to Spark installation, will try to find automatically
+        if not provided
+    """
+
+    if not spark_home:
+        spark_home = find()
+
     # ensure SPARK_HOME is defined
     os.environ['SPARK_HOME'] = spark_home
+
     # add pyspark to sys.path
     spark_python = os.path.join(spark_home, 'python')
     py4j = glob(os.path.join(spark_python, 'lib', 'py4j-*.zip'))[0]
     sys.path[:0] = [spark_python, py4j]
-    
-    return spark_home
-        

--- a/findspark.py
+++ b/findspark.py
@@ -12,7 +12,7 @@ __version__ = '0.0.2'
 
 
 def find():
-    """Find a local spark installation
+    """Find a local spark installation.
 
     Will first check the SPARK_HOME env variable, and otherwise
     search common installation locations, e.g. from homebrew
@@ -30,7 +30,7 @@ def find():
 
     if not spark_home:
         raise ValueError("Couldn't find Spark, make sure SPARK_HOME env is set"
-                         " or Spark is in an expected location (e.g. from homebrew installation).")
+                         "or Spark is in an expected location (e.g. from homebrew installation).")
 
     return spark_home
 


### PR DESCRIPTION
Considers splitting this into two functions, `find` and `init`. Pretty minor, but I found it slightly confusing to get the install location when I'm really running this just for initialization. It also makes room for expanding the initialization logic (which we might need for handling other configuration options).