### PR TITLE
Added option to persist changes by editing bash and csh config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,17 @@ To verify the automatically detected location, call
 findspark.find()
 ```
 
+Findspark can add a startup file to the current IPython profile so that the enviornment vaiables will be properly set and pyspark will be imported upon IPython startup. This file is created when `edit_profile` is set to true. A profile other than the current one can be modified using the `profile_name` option.
+
+```ipython --profile=myprofile
+findspark.init('/path/to/spark_home', edit_profile=True)
+findspark.init('/path/to/spark_home', edit_profile=True, profile_name='otherprofile')
+```
+
 Findspark can also add to .bashrc and .cshrc configuration files so that the enviornment variables will be properly set whenever a new shell is opened. This is enabled by setting the optional argument `persist_changes` to true.
 
 ```python
-findspark.init(persist_changes=True)
+findspark.init('/path/to/spark_home, 'edit_rc=True)
 ```
 
 If changes are persisted, findspark will not need to be called again unless the spark installation is moved.

--- a/README.md
+++ b/README.md
@@ -34,11 +34,10 @@ To verify the automatically detected location, call
 findspark.find()
 ```
 
-Findspark can add a startup file to the current IPython profile so that the enviornment vaiables will be properly set and pyspark will be imported upon IPython startup. This file is created when `edit_profile` is set to true. A profile other than the current one can be modified using the `profile_name` option.
+Findspark can add a startup file to the current IPython profile so that the enviornment vaiables will be properly set and pyspark will be imported upon IPython startup. This file is created when `edit_profile` is set to true.
 
 ```ipython --profile=myprofile
 findspark.init('/path/to/spark_home', edit_profile=True)
-findspark.init('/path/to/spark_home', edit_profile=True, profile_name='otherprofile')
 ```
 
 Findspark can also add to .bashrc and .cshrc configuration files so that the enviornment variables will be properly set whenever a new shell is opened. This is enabled by setting the optional argument `persist_changes` to true.

--- a/README.md
+++ b/README.md
@@ -33,3 +33,11 @@ To verify the automatically detected location, call
 ```python
 findspark.find()
 ```
+
+Findspark can also add to .bashrc and .cshrc configuration files so that the enviornment variables will be properly set whenever a new shell is opened. This is enabled by setting the optional argument `persist_changes` to true.
+
+```python
+findspark.init(persist_changes=True)
+```
+
+If changes are persisted, findspark will not need to be called again unless the spark installation is moved.

--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ Findspark can add a startup file to the current IPython profile so that the envi
 findspark.init('/path/to/spark_home', edit_profile=True)
 ```
 
-Findspark can also add to .bashrc and .cshrc configuration files so that the enviornment variables will be properly set whenever a new shell is opened. This is enabled by setting the optional argument `persist_changes` to true.
+Findspark can also add to .bashrc and .cshrc configuration files if they are present so that the enviornment variables will be properly set whenever a new shell is opened. This is enabled by setting the optional argument `edit_rc` to true.
 
 ```python
-findspark.init('/path/to/spark_home, 'edit_rc=True)
+findspark.init('/path/to/spark_home', edit_rc=True)
 ```
 
 If changes are persisted, findspark will not need to be called again unless the spark installation is moved.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Findspark can add a startup file to the current IPython profile so that the envi
 findspark.init('/path/to/spark_home', edit_profile=True)
 ```
 
-Findspark can also add to .bashrc and .cshrc configuration files if they are present so that the enviornment variables will be properly set whenever a new shell is opened. This is enabled by setting the optional argument `edit_rc` to true.
+Findspark can also add to the .bashrc configuration file if it is present so that the enviornment variables will be properly set whenever a new shell is opened. This is enabled by setting the optional argument `edit_rc` to true.
 
 ```python
 findspark.init('/path/to/spark_home', edit_rc=True)

--- a/findspark.py
+++ b/findspark.py
@@ -40,10 +40,9 @@ def find():
 def change_rc(spark_home, spark_python, py4j):
     """Persists changes to enviornment by changing shell config.
 
-    Adds lines to .bashrc and .cshrc to set enviornment variables 
+    Adds lines to .bashrc to set enviornment variables 
     including the adding of dependencies to the system path. Will only
-    edit these files if they already exist. Currently only works for bash 
-    and (t)csh.
+    edit this file if they already exist. Currently only works for bash.
 
     Parameters
     ----------
@@ -64,15 +63,6 @@ def change_rc(spark_home, spark_python, py4j):
             bashrc.write("export PYTHONPATH=" + spark_python + ":" + 
                          py4j + ":$PYTHONPATH\n\n")
     
-    cshrc_location = os.path.expanduser("~/.cshrc")
-    
-    if os.path.isfile(cshrc_location):
-        with open(cshrc_location, 'a') as cshrc:
-            cshrc.write("\n# Added by findspark\n")
-            cshrc.write("setenv SPARK_HOME " + spark_home + "\n")
-            cshrc.write("setenv PYTHONPATH \"" + spark_python + ":" +
-                        py4j + ":\"$PYTHONPATH")
- 
 
 def edit_ipython_profile(spark_home, spark_python, py4j):
     """Adds a startup file to the current IPython profile to import pyspark.

--- a/findspark.py
+++ b/findspark.py
@@ -8,7 +8,7 @@ from glob import glob
 import os
 import sys
 
-__version__ = '0.0.3'
+__version__ = '0.0.4'
 
 
 def find():
@@ -35,7 +35,42 @@ def find():
     return spark_home
 
 
-def init(spark_home=None):
+def persist(spark_home, spark_python, py4j):
+    """Persists changes to enviornment.
+
+    Adds lines to .bashrc to set enviornment variables including
+    the adding of dependencies to the system path. Currently only 
+    works for Bash.
+
+    Parameters
+    ----------
+    spark_home : str
+        Path to Spark installation.
+    spark_python : str
+        Path to python subdirectory of Spark installation.
+    py4j : str
+        Path to py4j library.
+    """
+
+    bashrc_location = os.path.expanduser("~/.bashrc")
+
+    with open(bashrc_location, 'a') as bashrc:
+        bashrc.write("\n# Added by findspark\n")
+        bashrc.write("export SPARK_HOME=" + spark_home + "\n")
+        bashrc.write("export PYTHONPATH=" + spark_python + ":" + 
+                     py4j + ":$PYTHONPATH\n\n")
+    
+    cshrc_location = os.path.expanduser("~/.cshrc")
+    
+    with open(cshrc_location, 'a') as cshrc:
+        cshrc.write("\n# Added by findspark\n")
+        cshrc.write("setenv SPARK_HOME " + spark_home + "\n")
+        cshrc.write("setenv PYTHONPATH \"" + spark_python + ":" +
+                    py4j + ":\"$PYTHONPATH")
+ 
+
+
+def init(spark_home=None, persist_changes=False):
     """Make pyspark importable.
 
     Sets environmental variables and adds dependencies to sys.path.
@@ -46,6 +81,9 @@ def init(spark_home=None):
     spark_home : str, optional, default = None
         Path to Spark installation, will try to find automatically
         if not provided
+    persist_changes : bool, optional, default = False
+        Whether to attempt to persist changes (currently only by
+        appending to bashrc).
     """
 
     if not spark_home:
@@ -58,3 +96,6 @@ def init(spark_home=None):
     spark_python = os.path.join(spark_home, 'python')
     py4j = glob(os.path.join(spark_python, 'lib', 'py4j-*.zip'))[0]
     sys.path[:0] = [spark_python, py4j]
+    
+    if persist_changes:
+        persist(spark_home, spark_python, py4j) 

--- a/findspark.py
+++ b/findspark.py
@@ -40,9 +40,10 @@ def find():
 def change_rc(spark_home, spark_python, py4j):
     """Persists changes to enviornment by changing shell config.
 
-    Adds lines to .bashrc to set enviornment variables including
-    the adding of dependencies to the system path. Currently only 
-    works for Bash and (t)csh.
+    Adds lines to .bashrc and .cshrc to set enviornment variables 
+    including the adding of dependencies to the system path. Will only
+    edit these files if they already exist. Currently only works for bash 
+    and (t)csh.
 
     Parameters
     ----------
@@ -56,19 +57,21 @@ def change_rc(spark_home, spark_python, py4j):
 
     bashrc_location = os.path.expanduser("~/.bashrc")
 
-    with open(bashrc_location, 'a') as bashrc:
-        bashrc.write("\n# Added by findspark\n")
-        bashrc.write("export SPARK_HOME=" + spark_home + "\n")
-        bashrc.write("export PYTHONPATH=" + spark_python + ":" + 
-                     py4j + ":$PYTHONPATH\n\n")
+    if os.path.isfile(bashrc_location):
+        with open(bashrc_location, 'a') as bashrc:
+            bashrc.write("\n# Added by findspark\n")
+            bashrc.write("export SPARK_HOME=" + spark_home + "\n")
+            bashrc.write("export PYTHONPATH=" + spark_python + ":" + 
+                         py4j + ":$PYTHONPATH\n\n")
     
     cshrc_location = os.path.expanduser("~/.cshrc")
     
-    with open(cshrc_location, 'a') as cshrc:
-        cshrc.write("\n# Added by findspark\n")
-        cshrc.write("setenv SPARK_HOME " + spark_home + "\n")
-        cshrc.write("setenv PYTHONPATH \"" + spark_python + ":" +
-                    py4j + ":\"$PYTHONPATH")
+    if os.path.isfile(cshrc_location):
+        with open(cshrc_location, 'a') as cshrc:
+            cshrc.write("\n# Added by findspark\n")
+            cshrc.write("setenv SPARK_HOME " + spark_home + "\n")
+            cshrc.write("setenv PYTHONPATH \"" + spark_python + ":" +
+                        py4j + ":\"$PYTHONPATH")
  
 
 def edit_ipython_profile(spark_home, spark_python, py4j):

--- a/findspark.py
+++ b/findspark.py
@@ -107,12 +107,12 @@ def init(spark_home=None, edit_rc=False, edit_profile=False):
     ----------
     spark_home : str, optional, default = None
         Path to Spark installation, will try to find automatically
-        if not provided
+        if not provided.
     edit_rc : bool, optional, default = False
         Whether to attempt to persist changes by appending to shell
         config.
     edit_profile : bool, optional, default = False
-        Whether to create a create an IPython startup file to automatically
+        Whether to create an IPython startup file to automatically
         configure and import pyspark.
     """
 

--- a/findspark.py
+++ b/findspark.py
@@ -71,7 +71,7 @@ def change_rc(spark_home, spark_python, py4j):
                     py4j + ":\"$PYTHONPATH")
  
 
-def edit_ipython_profile(spark_home, spark_python, py4j, name):
+def edit_ipython_profile(spark_home, spark_python, py4j):
     """Adds a startup file to the current IPython profile to import pyspark.
     
     The startup file sets the required enviornment variables and imports pyspark.
@@ -84,20 +84,15 @@ def edit_ipython_profile(spark_home, spark_python, py4j, name):
         Path to python subdirectory of Spark installation.
     py4j : str
         Path to py4j library.
-    name : str
-        Name of profile to create or append to.
     """
 
     ip = get_ipython()
 
-    if ip and name is None:
+    if ip:
         profile_dir = ip.profile_dir.location
     else:
         from IPython.utils.path import locate_profile
-        if name:
-            profile_dir = locate_profile(name)
-        else:
-            profile_dir = locate_profile()
+        profile_dir = locate_profile()
 
     startup_file_loc = os.path.join(profile_dir, "startup", "findspark.py")
         
@@ -109,7 +104,7 @@ def edit_ipython_profile(spark_home, spark_python, py4j, name):
         startup_file.write("import pyspark\n")       
         
 
-def init(spark_home=None, edit_rc=False, edit_profile=False, profile_name=None):
+def init(spark_home=None, edit_rc=False, edit_profile=False):
     """Make pyspark importable.
 
     Sets environmental variables and adds dependencies to sys.path.
@@ -126,9 +121,6 @@ def init(spark_home=None, edit_rc=False, edit_profile=False, profile_name=None):
     edit_profile : bool, optional, default = False
         Whether to create a create an IPython startup file to automatically
         configure and import pyspark.
-    profile_name : str, optional, default = None
-        Name of the IPython profile to create or edit if edit_profile is True.
-        Uses current profile if not set.
     """
 
     if not spark_home:
@@ -146,4 +138,4 @@ def init(spark_home=None, edit_rc=False, edit_profile=False, profile_name=None):
         change_rc(spark_home, spark_python, py4j) 
     
     if edit_profile:
-        edit_ipython_profile(spark_home, spark_python, py4j, profile_name)
+        edit_ipython_profile(spark_home, spark_python, py4j)


### PR DESCRIPTION
Adds a `persist_changes` option that appends commands to set the required environment variables to .bashrc and .cshrc so that findspark only needs to be called once.