### PR TITLE
using compatible Python for PYSPARK_PYTHON in init()

### DIFF
--- a/findspark.py
+++ b/findspark.py
@@ -10,7 +10,7 @@ import sys
 import subprocess
 from IPython import get_ipython
 
-__version__ = '0.0.4'
+__version__ = '0.0.5'
 
 
 def find():
@@ -97,7 +97,7 @@ def edit_ipython_profile(spark_home, spark_python, py4j):
         startup_file.write("import pyspark\n")       
         
 
-def init(spark_home=None, edit_rc=False, edit_profile=False):
+def init(spark_home=None, python_path=None, edit_rc=False, edit_profile=False):
     """Make pyspark importable.
 
     Sets environmental variables and adds dependencies to sys.path.
@@ -108,6 +108,9 @@ def init(spark_home=None, edit_rc=False, edit_profile=False):
     spark_home : str, optional, default = None
         Path to Spark installation, will try to find automatically
         if not provided.
+    python_path : str, optional, default = None
+        Path to Python for Spark workers (PYSPARK_PYTHON),
+        will use the currently running Python if not provided.
     edit_rc : bool, optional, default = False
         Whether to attempt to persist changes by appending to shell
         config.
@@ -119,8 +122,14 @@ def init(spark_home=None, edit_rc=False, edit_profile=False):
     if not spark_home:
         spark_home = find()
 
+    if not python_path:
+        python_path = sys.executable
+
     # ensure SPARK_HOME is defined
     os.environ['SPARK_HOME'] = spark_home
+
+    # ensure PYSPARK_PYTHON is defined
+    os.environ['PYSPARK_PYTHON'] = python_path
 
     # add pyspark to sys.path
     spark_python = os.path.join(spark_home, 'python')


### PR DESCRIPTION
See #6.

Right now I added it only for `init()`, not for saving. 

When it comes to `bash_rc` - it's on purpose, the whole point is to be able use the right Python executable, not - the default.

For the profile - are they tied to a single Python version (including minor) or not (@Carreau)? If the former, I should add option to save it to the profile as well.