### PR TITLE
Respect PYSPARK_PYTHON when present

### DIFF
--- a/findspark.py
+++ b/findspark.py
@@ -121,7 +121,7 @@ def init(spark_home=None, python_path=None, edit_rc=False, edit_profile=False):
         spark_home = find()
 
     if not python_path:
-        python_path = sys.executable
+        python_path = os.environ.get('PYSPARK_PYTHON', sys.executable)
 
     # ensure SPARK_HOME is defined
     os.environ['SPARK_HOME'] = spark_home


### PR DESCRIPTION
In case python_path is not given, but `PYSPARK_PYTHON` is set, it's not
advisable to overwrite `PYSPARK_PYTHON`.

The reason is that, if the system administrator set PYSPARK_PYTHON to something custom, the developer should not be burdened by setting `python_path` in findspark.