### PR TITLE
Add /usr/lib/spark/ to possible SPARK_HOME

### DIFF
--- a/findspark.py
+++ b/findspark.py
@@ -22,6 +22,7 @@ def find():
     if not spark_home:
         for path in [
             '/usr/local/opt/apache-spark/libexec', # OS X Homebrew
+            '/usr/lib/spark/' # AWS Amazon EMR
             # Any other common places to look?
         ]:
             if os.path.exists(path):


### PR DESCRIPTION
This value is used by Amazon AWS EMR clusters