### PR TITLE
Added another common linux path for spark

### DIFF
--- a/findspark.py
+++ b/findspark.py
@@ -23,7 +23,8 @@ def find():
         for path in [
             '/usr/local/opt/apache-spark/libexec', # OS X Homebrew
             '/usr/lib/spark/', # AWS Amazon EMR
-            '/usr/local/spark/' # common linux path for spark
+            '/usr/local/spark/', # common linux path for spark
+            '/opt/spark/' # other common linux path for spark
             # Any other common places to look?
         ]:
             if os.path.exists(path):

--- a/findspark.py
+++ b/findspark.py
@@ -24,7 +24,7 @@ def find():
             '/usr/local/opt/apache-spark/libexec', # OS X Homebrew
             '/usr/lib/spark/', # AWS Amazon EMR
             '/usr/local/spark/', # common linux path for spark
-            '/opt/spark/' # other common linux path for spark
+            '/opt/spark/', # other common linux path for spark
             # Any other common places to look?
         ]:
             if os.path.exists(path):


### PR DESCRIPTION
Many people choose */opt* directory to install external software.
Adding this directory, would helpful. 