### PR TITLE
Added descriptive error when py4j can't be found

### DIFF
--- a/findspark.py
+++ b/findspark.py
@@ -137,7 +137,10 @@ def init(spark_home=None, python_path=None, edit_rc=False, edit_profile=False):
 
     # add pyspark to sys.path
     spark_python = os.path.join(spark_home, 'python')
-    py4j = glob(os.path.join(spark_python, 'lib', 'py4j-*.zip'))[0]
+    try:
+        py4j = glob(os.path.join(spark_python, 'lib', 'py4j-*.zip'))[0]
+    except IndexError:
+        raise Exception("Unable to find py4j, your SPARK_HOME may not be configured correctly")
     sys.path[:0] = [spark_python, py4j]
 
     if edit_rc:


### PR DESCRIPTION
Ran into this issue while attempting to use the library and got a "IndexError", this change makes it much more clear that something is probably wrong with the user's config of Spark, since py4j cannot be found (at least, this is what happened in my case, open to a more general rephrasing).