### PR TITLE
importable spark overrides $SPARK_HOME

### DIFF
--- a/findspark.py
+++ b/findspark.py
@@ -33,13 +33,14 @@ def find():
                 spark_home = path
                 break
 
-    # last resort: try importing pyspark (pip-installed, already on sys.path)
-    try:
-        import pyspark
-    except ImportError:
-        pass
-    else:
-        spark_home = os.path.dirname(pyspark.__file__)
+    if not spark_home:
+        # last resort: try importing pyspark (pip-installed, already on sys.path)
+        try:
+            import pyspark
+        except ImportError:
+            pass
+        else:
+            spark_home = os.path.dirname(pyspark.__file__)
 
     if not spark_home:
         raise ValueError(


### PR DESCRIPTION
Without a guard if statement /usr/local/spark will not be used if pyspark is installed.  This breaks getting the correct spark-env.sh even with the pyspark versions are the same.